### PR TITLE
Updates

### DIFF
--- a/99robots-header-footer-code-manager.php
+++ b/99robots-header-footer-code-manager.php
@@ -23,6 +23,10 @@ $hfcm_db_version = '1.1';
 // function to create the DB / Options / Defaults
 function hfcm_options_install() {
 
+	$hfcm_now = strtotime( "now" );
+  add_option( 'hfcm_activation_date', $hfcm_now );
+	update_option( 'hfcm_activation_date', $hfcm_now );
+
 	global $wpdb;
 	global $hfcm_db_version;
 
@@ -55,6 +59,7 @@ function hfcm_options_install() {
 	require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 	dbDelta( $sql );
 	add_option( 'hfcm_db_version', $hfcm_db_version );
+
 }
 register_activation_hook( __FILE__, 'hfcm_options_install' );
 
@@ -197,6 +202,21 @@ function hfcm_add_plugin_page_settings_link( $links ) {
 	return $links;
 }
 
+//Check Installation Date
+function hfcm_check_installation_date() {
+
+    $install_date = get_option( 'hfcm_activation_date' );
+    $past_date = strtotime( '-7 days' );
+
+    if ( $past_date >= $install_date ) {
+
+        add_action( 'admin_notices', 'hfcm_review_push_notice' );
+
+    }
+
+}
+add_action( 'admin_init', 'hfcm_check_installation_date' );
+
 // Create the Admin Notice
 function hfcm_review_push_notice() {
 
@@ -209,7 +229,7 @@ function hfcm_review_push_notice() {
 
 	$user_id = get_current_user_id();
 	// Check if current user has already dismissed it
-
+	$install_date = get_option( 'hfcm_activation_date' );
   if ( !get_user_meta( $user_id, 'hfcm_plugin_notice_dismissed') && in_array($screen, $allowed_pages_notices)) {
     ?>
     <div id="hfcm-message" class="notice notice-success">
@@ -219,7 +239,6 @@ function hfcm_review_push_notice() {
     <?php
 	}
 }
-add_action( 'admin_notices', 'hfcm_review_push_notice' );
 
 // Check if current user has already dismissed it
 function hfcm_plugin_notice_dismissed() {

--- a/includes/hfcm-add-edit.php
+++ b/includes/hfcm-add-edit.php
@@ -71,7 +71,7 @@ wp_enqueue_script( 'hfcm_showboxes' );
 			's_posts'        => esc_html__( 'Specific Posts', '99robots-header-footer-code-manager' ),
 			's_pages'        => esc_html__( 'Specific Pages', '99robots-header-footer-code-manager' ),
 			's_categories'   => esc_html__( 'Specific Categories', '99robots-header-footer-code-manager' ),
-			's_custom_posts' => esc_html__( 'Specific Custom Post Types', '99robots-header-footer-code-manager' ),
+			's_custom_posts' => esc_html__( 'Specific Post Types', '99robots-header-footer-code-manager' ),
 			's_tags'         => esc_html__( 'Specific Tags', '99robots-header-footer-code-manager' ),
 			'latest_posts'   => esc_html__( 'Latest Posts', '99robots-header-footer-code-manager' ),
 			'manual'         => esc_html__( 'Shortcode Only', '99robots-header-footer-code-manager' ),
@@ -165,10 +165,9 @@ wp_enqueue_script( 'hfcm_showboxes' );
 		$lpcountstyle = 'latest_posts' === $display_on ? '' : 'display:none;';
 		$locationstyle = 'manual' === $display_on ? 'display:none;' : '';
 
-		// Get all names of Custom Post Types
+		// Get all names of Post Types
 		$args = array(
 			'public' => true,
-			'_builtin' => false,
 		);
 
 		$output = 'names';
@@ -213,7 +212,7 @@ wp_enqueue_script( 'hfcm_showboxes' );
 			</td>
 		</tr>
 		<tr id="c_posttype" style="<?php echo $cpostssstyle; ?>">
-			<th class="hfcm-th-width"><?php esc_html_e( 'Custom Post Types', '99robots-header-footer-code-manager' ); ?></th>
+			<th class="hfcm-th-width"><?php esc_html_e( 'Post Types', '99robots-header-footer-code-manager' ); ?></th>
 			<td>
 				<select name="data[s_custom_posts][]" multiple>
 				<?php

--- a/includes/hfcm-list.php
+++ b/includes/hfcm-list.php
@@ -25,7 +25,7 @@ class Hfcm_Snippets_List extends WP_List_Table {
 	 *
 	 * @return mixed
 	 */
-	public static function get_snippets( $per_page = 10, $page_number = 1, $customvar = 'all' ) {
+	public static function get_snippets( $per_page = 20, $page_number = 1, $customvar = 'all' ) {
 
 		global $wpdb;
 		$table_name = "{$wpdb->prefix}hfcm_scripts";
@@ -320,7 +320,7 @@ class Hfcm_Snippets_List extends WP_List_Table {
 		/** Process bulk action */
 		$this->process_bulk_action();
 		$this->views();
-		$per_page = $this->get_items_per_page( 'snippets_per_page', 10 );
+		$per_page = $this->get_items_per_page( 'snippets_per_page', 20 );
 		$current_page = $this->get_pagenum();
 		$total_items = self::record_count();
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: 99robots, charliepatel
 Tags: header, footer, code manager, snippet, functions.php, tracking, google analytics, adsense, verification, pixel
 Requires at least: 4.0
-Tested up to: 5.1.1
-Stable tag: 1.1.3
+Tested up to: 5.2.2
+Stable tag: 1.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://99robots.com
@@ -106,6 +106,11 @@ A. Free plugins rely on user feedback. Therefore, the best thing you can do for 
 A. If your script is not supported, just let us know and we'll look into it immediately. We will do our best to ensure all reputable services are supported. When requesting support for a particular script, it would be nice to get a sample of the script so that we can see its structure.
 
 == Changelog ==
+
+= 1.1.4 = 2019-05-03
+* UPDATED: All snippets page now shows 20 snippets instead of 10
+* ADDED: Functionality to add code snippets to all post types, including posts, pages, custom post types & attachments
+* UPDATED: Compatibility with WordPress 5.2.2
 
 = 1.1.3 = 2019-05-03
 * UPDATED: Compatibility with WordPress 5.1.1


### PR DESCRIPTION
1. Including all Post Types instead of just CPTs
2. Updating the All Scripts section to show 20 scripts instead of just 10
3. The Notice for review will show 1 week after the user has had the plugin active, instead of from the beginning.
4. Compatibility with WP 5.2.2